### PR TITLE
bug fixes for 2.0.4

### DIFF
--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/html-helpers/one-to-many-iframe-logic.ts
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/html-helpers/one-to-many-iframe-logic.ts
@@ -26,6 +26,7 @@ function ready() {
 	 * Initialization code, will execute before emitting iframe-ready event
 	 */
 	function init() {
+		Array.from(document.links).forEach(x => (x.href = '#')); // disable links
 		matches = Array.from(document.querySelectorAll('span[match]'));
 		matches.forEach(elem => {
 			elem.addEventListener('click', onMatchClick);

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/html-helpers/one-to-one-iframe-logic.ts
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/html-helpers/one-to-one-iframe-logic.ts
@@ -19,10 +19,12 @@ function ready() {
 	let groups: { [gid: string]: HTMLSpanElement[] };
 	window.addEventListener('message', handleMessageFromParent);
 	init();
+
 	/**
 	 * Initialization code, will execute before emitting iframe-ready event
 	 */
 	function init() {
+		Array.from(document.links).forEach(x => (x.href = '#')); // disable links
 		matches = Array.from(document.querySelectorAll('span[match]'));
 		groups = matches.reduce((prev, curr) => {
 			prev[curr.dataset.gid] = prev[curr.dataset.gid] || [];

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/original/original.component.scss
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/original/original.component.scss
@@ -6,6 +6,7 @@
 
 [text-container] {
 	white-space: pre-line;
+	word-break: break-word;
 	padding: 1em;
 
 	i {

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/properties/properties.component.html
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/properties/properties.component.html
@@ -48,15 +48,16 @@
 							<ng-container *ngIf="!done && progress !== null">
 								{{ progress && progress / 100 | percent: '1.0' }}
 							</ng-container>
-							<ng-container *ngIf="done">
-								done
-							</ng-container>
+							<ng-container *ngIf="done">done</ng-container>
 						</div>
 					</div>
 				</div>
 				<div>
-					<ng-container *ngIf="!done">
-						scanning...
+					<ng-container *ngIf="isScanning && !done">
+						Scanning...
+					</ng-container>
+					<ng-container *ngIf="!isScanning && !done">
+						Loading...
 					</ng-container>
 					<ng-container *ngIf="done">
 						<div *ngIf="metadata"
@@ -119,7 +120,8 @@
 							 fxLayout="row"
 							 fxLayoutAlign="start center"
 							 fxLayoutGap="0.5em">
-						<div class="dot identical"></div>
+						<div class="dot identical"
+								 [ngStyle]="{'visibility': options?.showIdentical? 'visible':'hidden'}"></div>
 						<div text
 								 [ngClass]="{ 'cr-strike-out': !options?.showIdentical }">
 							Identical
@@ -137,9 +139,10 @@
 							 fxLayout="row"
 							 fxLayoutAlign="center center"
 							 fxLayoutGap="0.5em">
-						<div class="dot minor-changes"></div>
+						<div class="dot minor-changes"
+								 [ngStyle]="{'visibility': options?.showMinorChanges ? 'visible':'hidden'}"></div>
 						<div text
-								 [ngClass]="{ 'cr-strike-out': options.showMinorChanges !== true }">
+								 [ngClass]="{ 'cr-strike-out': options?.showMinorChanges !== true }">
 							Minor Changes
 						</div>
 						<span fxFlex></span>
@@ -154,9 +157,10 @@
 							 fxLayout="row"
 							 fxLayoutAlign="start center"
 							 fxLayoutGap="0.5em">
-						<div class="dot related"></div>
+						<div class="dot related"
+								 [ngStyle]="{'visibility': options?.showRelated?  'visible':'hidden'}"></div>
 						<div text
-								 [ngClass]="{ 'cr-strike-out': options.showRelated !== true }">
+								 [ngClass]="{ 'cr-strike-out': options?.showRelated !== true }">
 							Related Meaning
 						</div>
 						<span fxFlex></span>

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/properties/properties.component.scss
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/properties/properties.component.scss
@@ -73,10 +73,6 @@ cr-expansion-panel-body {
 					cursor: pointer;
 				}
 
-				&:hover {
-					background: rgba(0, 0, 0, 0.04);
-				}
-
 				[text] {
 					white-space: nowrap;
 				}

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/properties/properties.component.ts
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/properties/properties.component.ts
@@ -47,6 +47,9 @@ export class PropertiesComponent implements OnInit, OnDestroy {
 		private statistics: StatisticsService
 	) {}
 
+	get isScanning() {
+		return this.progress && (this.progress >= 0 || this.progress < 100);
+	}
 	get done() {
 		return this.progress === 100;
 	}

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/components/result-card/result-card.component.html
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/components/result-card/result-card.component.html
@@ -20,7 +20,8 @@
 	<div footer
 			 fxLayout="row"
 			 fxLayoutAlign="space-between stretch">
-		<div [ngClass]="{ 'text-identical': true }">{{ preview.matchedWords | shortNumber: 2 }} similar words</div>
+		<div [ngClass]="{ 'text-identical': true }">{{ preview.matchedWords / source.metadata.words | percent  }} similar
+			words</div>
 		<div fxLayout="row"
 				 fxLayoutGap="1em"
 				 style="height: 28px"
@@ -32,13 +33,20 @@
 		</div>
 	</div>
 	<sat-popover #popover
-							 horizontalAlign="after">
+							 horizontalAlign="before">
 		<div fxLayout="column nowrap"
 				 fxLayoutAlign="start start"
-				 class="sat-tooltip">
-			<div class="text-identical">identical - {{ result?.statistics.identical | number }} words</div>
-			<div class="text-minor-changes">minor changes - {{ result?.statistics.minorChanges | number }} words</div>
-			<div class="text-related">related - {{ result?.statistics.relatedMeaning | number }} words</div>
+				 class="sat-tooltip mat-typography">
+			<div class="text-identical">Identical -
+				{{ result?.statistics.identical / source?.metadata.words | percent }}
+				words
+			</div>
+			<div class="text-minor-changes">Minor Changes -
+				{{ result?.statistics.minorChanges / source?.metadata.words| percent }} words</div>
+			<div class="text-related">Related Meaning -
+				{{ result?.statistics.relatedMeaning / source?.metadata.words| percent }}
+				words
+			</div>
 		</div>
 	</sat-popover>
 </ng-container>

--- a/client/projects/plagiarism-report/src/lib/plagiarism-report/utils/match-helpers.spec.ts
+++ b/client/projects/plagiarism-report/src/lib/plagiarism-report/utils/match-helpers.spec.ts
@@ -15,6 +15,21 @@ describe('match-helpers', () => {
 				);
 			});
 		});
+		describe('pdf case', () => {
+			const data: Match[] = [
+				{ start: 213, end: 228, type: 1, ids: ['A'] },
+				{ start: 221, end: 246, type: 0, ids: ['A'] },
+			];
+			it('same ids but different types', () => {
+				const result: Match[] = mergeMatches(data);
+				expect(result).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ start: 213, end: 221, type: 1, ids: expect.arrayContaining(['A']) }),
+						expect.objectContaining({ start: 221, end: 246, type: 0, ids: expect.arrayContaining(['A']) }),
+					])
+				);
+			});
+		});
 	});
 
 	describe('groupIntervals', () => {


### PR DESCRIPTION
disable links in iframe  due to network errors

fix words not breaking when too long in text view.

display "loading" text when scan does not have a progress.
remove comparison types circles when the specific type is disabled in statistics section.
remove hover effect from statistics section.

display percentage instead of word count on result cards

fix spltting of matches to sub matches.
merge matches after splitting them.
add tests for the changes above.